### PR TITLE
Please make this class abstract to prevent "No tests found in class "PHPUnit_Extensions_Mockery_TestCase"  " error and failing tests.

### DIFF
--- a/PHPUnit/Extensions/Mockery/TestCase.php
+++ b/PHPUnit/Extensions/Mockery/TestCase.php
@@ -8,7 +8,7 @@ $loader->register();
 
 use \Mockery;
 
-class PHPUnit_Extensions_Mockery_TestCase extends PHPUnit_Framework_TestCase {
+abstract class PHPUnit_Extensions_Mockery_TestCase extends PHPUnit_Framework_TestCase {
 
     const REGEX_MOCK = '/@mockery\s+([a-zA-Z0-9._:-\\\\x7f-\xff]+)/';
     


### PR DESCRIPTION
... in class "PHPUnit_Extensions_Mockery_TestCase"." error in PHPUnit 3.6
