### PR TITLE
Hamcrest dependency not needed, satisfied by Mockery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     "require": {
         "php": ">=5.3.6",
         "phpunit/PHPUnit": ">=3.6.10",
-        "mockery/mockery": "dev-master",
-        "davedevelopment/hamcrest-php": "dev-master"
+        "mockery/mockery": "dev-master"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Removing the hamcrest dependency as this is satisfied by Mockery.

Also, this should be registered on packagist. Additionally, the github hook for packagist should also be set up.
