### PR TITLE
Updated dependencies in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     "require": {
         "php": ">=5.3.6",
         "phpunit/PHPUnit": ">=3.6.10",
-        "mockery/mockery": "dev-master",
-        "davedevelopment/hamcrest-php": "dev-master"
+        "mockery/mockery": "0.8.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
- Pinned mockery dependency to version 0.8.0 for stability
- Removed hamcrest dependency (taken from a previous pull request from sqmk that hasn't been merged yet)
